### PR TITLE
[chore] Prepare release v1.32.2/v0.126.2

### DIFF
--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -39,7 +39,7 @@ if [ "${CANDIDATE_BETA}" != "" ]; then
     COMMANDS+="
 - make prepare-release PREVIOUS_VERSION=${CURRENT_BETA_ESCAPED} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta"
 fi
-git push --set-upstream origin "${BRANCH}"
+git push --set-upstream jackgopack4 "${BRANCH}"
 
 # Use OpenTelemetryBot account to create PR, allowing workflows to run
 # The title must match the checks in check-merge-freeze.yml

--- a/.github/workflows/scripts/release-push-tags.sh
+++ b/.github/workflows/scripts/release-push-tags.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# --- Configuration ---
+RELEASE_SERIES="$1" # e.g., v0.85.x
+PREPARE_RELEASE_COMMIT_HASH="$2" # Optional: Specific commit hash for "Prepare release"
+UPSTREAM_REMOTE_NAME=${UPSTREAM_REMOTE_NAME:-"upstream"} # Your upstream remote name for open-telemetry/opentelemetry-collector
+MAIN_BRANCH_NAME=${MAIN_BRANCH_NAME:-"main"}
+LOCAL_MAIN_BRANCH_NAME=${LOCAL_MAIN_BRANCH_NAME:-"${MAIN_BRANCH_NAME}"}
+TARGET_REPO_URL=${TARGET_REPO_URL:-"https://github.com/${UPSTREAM_REMOTE_NAME}/opentelemetry-collector.git"} # Used for REMOTE env var
+
+# --- Helper Functions ---
+check_command_success() {
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Command failed - '$1'. See output above for details."
+    exit 1
+  fi
+}
+
+# --- Validate Input ---
+if [[ -z "$RELEASE_SERIES" ]]; then
+  echo "Error: Release series not provided."
+  echo "Usage: $0 <release-series> [prepare-release-commit-hash]"
+  echo "Example: $0 v0.85.x"
+  echo "Example: $0 v0.85.x a1b2c3d4"
+  exit 1
+fi
+
+RELEASE_BRANCH_NAME="release/${RELEASE_SERIES}"
+
+echo "Automating Release Steps for: ${RELEASE_SERIES}"
+echo "Release Branch Name: ${RELEASE_BRANCH_NAME}"
+if [[ -n "$PREPARE_RELEASE_COMMIT_HASH" ]]; then
+  echo "Will use specific 'Prepare release' commit: ${PREPARE_RELEASE_COMMIT_HASH}"
+else
+  echo "Will use HEAD of '${UPSTREAM_REMOTE_NAME}/${MAIN_BRANCH_NAME}' (after fetch/rebase) as 'Prepare release' commit."
+fi
+echo "Upstream Remote: ${UPSTREAM_REMOTE_NAME}"
+echo "--------------------------------------------------"
+
+# --- Step 4: Checkout main, Pull, Create/Update and Push Release Branch ---
+echo ""
+echo "=== Step 4: Preparing and Pushing Release Branch ==="
+
+# 1. Checkout main
+echo "1. Checking out '${MAIN_BRANCH_NAME}' branch..."
+git checkout "${LOCAL_MAIN_BRANCH_NAME}"
+check_command_success "git checkout ${LOCAL_MAIN_BRANCH_NAME}"
+
+# 2. Fetch from upstream (updates remote-tracking branches including potential existing release branch)
+echo "2. Fetching from '${UPSTREAM_REMOTE_NAME}'..."
+git fetch "${UPSTREAM_REMOTE_NAME}"
+check_command_success "git fetch ${UPSTREAM_REMOTE_NAME}"
+
+# 3. Rebase local main with upstream/main
+echo "3. Rebasing local '${MAIN_BRANCH_NAME}' with '${UPSTREAM_REMOTE_NAME}/${MAIN_BRANCH_NAME}'..."
+git rebase "${UPSTREAM_REMOTE_NAME}/${MAIN_BRANCH_NAME}"
+check_command_success "git rebase ${UPSTREAM_REMOTE_NAME}/${MAIN_BRANCH_NAME}"
+echo "'${LOCAL_MAIN_BRANCH_NAME}' branch is now up-to-date."
+
+# Determine the target commit from main that the release branch should be based on or merge
+TARGET_MAIN_STATE_COMMIT=""
+if [[ -n "$PREPARE_RELEASE_COMMIT_HASH" ]]; then
+  TARGET_MAIN_STATE_COMMIT="$PREPARE_RELEASE_COMMIT_HASH"
+  # Verify the commit exists (it should be reachable from main after fetch)
+  if ! git cat-file -e "${TARGET_MAIN_STATE_COMMIT}^{commit}" 2>/dev/null; then
+    echo "Error: Provided 'Prepare release' commit hash '${TARGET_MAIN_STATE_COMMIT}' not found."
+    exit 1
+  fi
+  echo "Targeting specific commit from main: ${TARGET_MAIN_STATE_COMMIT}"
+else
+  # If no specific commit is given, use the current HEAD of the rebased local main branch
+  TARGET_MAIN_STATE_COMMIT=$(git rev-parse HEAD) # Assumes we are still on 'main'
+  echo "Targeting current HEAD of rebased '${MAIN_BRANCH_NAME}': ${TARGET_MAIN_STATE_COMMIT}"
+fi
+
+# 4. Handle Release Branch: Check existence, create or switch, and merge/base
+echo "4. Checking for existing release branch '${RELEASE_BRANCH_NAME}'..."
+BRANCH_EXISTS_LOCALLY=$(git branch --list "${RELEASE_BRANCH_NAME}")
+# Check remote by looking for the remote tracking branch ref after fetch
+BRANCH_EXISTS_REMOTELY=$(git rev-parse --verify --quiet "${UPSTREAM_REMOTE_NAME}/${RELEASE_BRANCH_NAME}")
+
+MERGE_NEEDED=false
+
+if [[ -n "$BRANCH_EXISTS_REMOTELY" ]]; then
+  echo "Release branch '${RELEASE_BRANCH_NAME}' found on remote '${UPSTREAM_REMOTE_NAME}'."
+  MERGE_NEEDED=true
+  if [[ -n "$BRANCH_EXISTS_LOCALLY" ]]; then
+    echo "Switching to existing local branch '${RELEASE_BRANCH_NAME}'."
+    git switch "${RELEASE_BRANCH_NAME}"
+    check_command_success "git switch ${RELEASE_BRANCH_NAME}"
+    echo "Resetting local '${RELEASE_BRANCH_NAME}' to match '${UPSTREAM_REMOTE_NAME}/${RELEASE_BRANCH_NAME}' to ensure consistency."
+    git reset --hard "${UPSTREAM_REMOTE_NAME}/${RELEASE_BRANCH_NAME}"
+    check_command_success "git reset --hard ${UPSTREAM_REMOTE_NAME}/${RELEASE_BRANCH_NAME}"
+  else
+    echo "Creating local branch '${RELEASE_BRANCH_NAME}' to track '${UPSTREAM_REMOTE_NAME}/${RELEASE_BRANCH_NAME}'."
+    git switch -c "${RELEASE_BRANCH_NAME}" "${UPSTREAM_REMOTE_NAME}/${RELEASE_BRANCH_NAME}"
+    check_command_success "git switch -c ${RELEASE_BRANCH_NAME} (tracking remote)"
+  fi
+elif [[ -n "$BRANCH_EXISTS_LOCALLY" ]]; then
+  echo "Release branch '${RELEASE_BRANCH_NAME}' found locally but not on remote '${UPSTREAM_REMOTE_NAME}'."
+  MERGE_NEEDED=true
+  echo "Switching to local branch '${RELEASE_BRANCH_NAME}'."
+  git switch "${RELEASE_BRANCH_NAME}"
+  check_command_success "git switch ${RELEASE_BRANCH_NAME}"
+  # No reset needed here as there's no remote counterpart to reset to.
+  # We'll merge main into this local state.
+else
+  echo "Release branch '${RELEASE_BRANCH_NAME}' not found locally or on remote."
+  echo "Creating new branch '${RELEASE_BRANCH_NAME}' from commit '${TARGET_MAIN_STATE_COMMIT}'."
+  git switch -c "${RELEASE_BRANCH_NAME}" "${TARGET_MAIN_STATE_COMMIT}"
+  check_command_success "git switch -c ${RELEASE_BRANCH_NAME} ${TARGET_MAIN_STATE_COMMIT}"
+  # MERGE_NEEDED remains false as the branch is created directly from the target commit
+fi
+
+if [[ "$MERGE_NEEDED" == true ]]; then
+  echo "Merging latest from '${MAIN_BRANCH_NAME}' (commit: ${TARGET_MAIN_STATE_COMMIT}) into '${RELEASE_BRANCH_NAME}'..."
+  git merge "${TARGET_MAIN_STATE_COMMIT}"
+  check_command_success "git merge ${TARGET_MAIN_STATE_COMMIT} into ${RELEASE_BRANCH_NAME}"
+  echo "Merge complete. Current status:"
+  git status -s # Short status
+fi
+
+echo "Current branch is now '${RELEASE_BRANCH_NAME}'."
+git --no-pager log -1 --pretty=oneline # Show the commit at the tip of the release branch
+
+# 5. Push the release branch to upstream
+echo "5. Pushing branch '${RELEASE_BRANCH_NAME}' to '${UPSTREAM_REMOTE_NAME}'..."
+git push -u "${UPSTREAM_REMOTE_NAME}" "${RELEASE_BRANCH_NAME}"
+check_command_success "git push -u ${UPSTREAM_REMOTE_NAME} ${RELEASE_BRANCH_NAME}"
+echo "Branch '${RELEASE_BRANCH_NAME}' pushed (or updated) on '${UPSTREAM_REMOTE_NAME}'."
+echo "Step 4 completed."
+echo "--------------------------------------------------"
+
+
+# --- Step 5: Tag and Push Module Group Tags ---
+echo ""
+echo "=== Step 5: Tagging and Pushing Module Group Tags ==="
+
+# 1. Ensure you are on the release branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH_NAME" ]]; then
+  echo "Error: Not on the release branch '${RELEASE_BRANCH_NAME}'. Currently on '${CURRENT_BRANCH}'."
+  echo "This should not happen if Step 4 completed correctly."
+  exit 1
+fi
+echo "1. Confirmed on branch '${RELEASE_BRANCH_NAME}'."
+
+# 2. Handle REMOTE env var for make if using HTTPS remote
+# MAKE_COMMAND_PREFIX=""
+# REMOTE_GIT_URL=$(git remote get-url "$UPSTREAM_REMOTE_NAME" 2>/dev/null)
+echo "Setting REMOTE for make push-tags commands."
+MAKE_COMMAND_PREFIX="REMOTE=${TARGET_REPO_URL} "
+
+# 3. Push beta tags
+echo "3. Pushing beta module tags..."
+eval "${MAKE_COMMAND_PREFIX}make push-tags MODSET=beta"
+check_command_success "${MAKE_COMMAND_PREFIX}make push-tags MODSET=beta"
+echo "Beta tags pushed."
+
+# 4. Conditionally push stable tags
+echo "4. Checking for changes and pushing stable module tags (if any)..."
+# As discussed, this relies on 'make push-tags MODSET=stable' being idempotent
+# or having its own change detection. If not, further logic is needed here.
+eval "${MAKE_COMMAND_PREFIX}make push-tags MODSET=stable"
+echo "Stable tags command executed. Check its output for details."
+echo "Step 5 completed."
+echo "--------------------------------------------------"
+
+echo ""
+echo "Automation for your Steps 4 and 5 is complete."
+echo "Next, you would typically proceed to your Step 6: 'Wait for the new tag build to pass successfully.'"

--- a/CHANGELOG-API.md
+++ b/CHANGELOG-API.md
@@ -7,6 +7,10 @@ If you are looking for user-facing changes, check out [CHANGELOG.md](./CHANGELOG
 
 <!-- next version -->
 
+## v1.32.2/v0.126.2
+
+<!-- previous-version -->
+
 ## v1.32.1/v0.126.1
 
 ### 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 
 <!-- next version -->
 
+## v1.32.2/v0.126.2
+
+<!-- previous-version -->
+
 ## v1.32.1/v0.126.1
 
 <!-- previous-version -->

--- a/client/go.mod
+++ b/client/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.32.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultBetaOtelColVersion   = "v0.126.1"
-	defaultStableOtelColVersion = "v1.32.1"
+	defaultStableOtelColVersion = "v1.32.2"
 )
 
 // errMissingGoMod indicates an empty gomod field

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultBetaOtelColVersion   = "v0.126.1"
+	defaultBetaOtelColVersion   = "v0.126.2"
 	defaultStableOtelColVersion = "v1.32.2"
 )
 

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -10,24 +10,24 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.126.1-dev
+  version: 0.126.2-dev
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.126.1
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.126.2
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.2
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.1
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.126.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.2
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.126.2
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.126.2
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.2
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.1
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
+  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.2
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.2
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.126.1
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.126.2
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.2
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.1
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.2
 
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -30,9 +30,9 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.1
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
 

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -4,10 +4,10 @@ dist:
   go: ${GOBIN}
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.2
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.2
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.2

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -7,22 +7,22 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/filter v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/filter v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/scraper v0.126.1
-	go.opentelemetry.io/collector/scraper/scrapertest v0.126.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/scraper v0.126.2
+	go.opentelemetry.io/collector/scraper/scrapertest v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
@@ -53,18 +53,18 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -6,20 +6,20 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/filter v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.opentelemetry.io/collector/scraper v0.126.1
 	go.opentelemetry.io/collector/scraper/scrapertest v0.126.1
@@ -57,7 +57,7 @@ require (
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -10,24 +10,24 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.126.1-dev
+  version: 0.126.2-dev
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.126.1
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.126.2
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.2
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.1
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.126.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.126.2
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.126.2
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.126.2
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.2
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.1
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
+  - gomod: go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.2
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.126.2
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.126.1
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.126.2
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.2
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.1
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.2
 
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -30,11 +30,11 @@ connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.126.1
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.1
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.1
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.2
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/components.go
+++ b/cmd/otelcorecol/components.go
@@ -35,8 +35,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ExtensionModules = make(map[component.Type]string, len(factories.Extensions))
-	factories.ExtensionModules[memorylimiterextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.1"
-	factories.ExtensionModules[zpagesextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/zpagesextension v0.126.1"
+	factories.ExtensionModules[memorylimiterextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.2"
+	factories.ExtensionModules[zpagesextension.NewFactory().Type()] = "go.opentelemetry.io/collector/extension/zpagesextension v0.126.2"
 
 	factories.Receivers, err = otelcol.MakeFactoryMap[receiver.Factory](
 		nopreceiver.NewFactory(),
@@ -46,8 +46,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ReceiverModules = make(map[component.Type]string, len(factories.Receivers))
-	factories.ReceiverModules[nopreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/nopreceiver v0.126.1"
-	factories.ReceiverModules[otlpreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1"
+	factories.ReceiverModules[nopreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/nopreceiver v0.126.2"
+	factories.ReceiverModules[otlpreceiver.NewFactory().Type()] = "go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.2"
 
 	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](
 		debugexporter.NewFactory(),
@@ -59,10 +59,10 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ExporterModules = make(map[component.Type]string, len(factories.Exporters))
-	factories.ExporterModules[debugexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/debugexporter v0.126.1"
-	factories.ExporterModules[nopexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/nopexporter v0.126.1"
-	factories.ExporterModules[otlpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1"
-	factories.ExporterModules[otlphttpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1"
+	factories.ExporterModules[debugexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/debugexporter v0.126.2"
+	factories.ExporterModules[nopexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/nopexporter v0.126.2"
+	factories.ExporterModules[otlpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlpexporter v0.126.2"
+	factories.ExporterModules[otlphttpexporter.NewFactory().Type()] = "go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.2"
 
 	factories.Processors, err = otelcol.MakeFactoryMap[processor.Factory](
 		batchprocessor.NewFactory(),
@@ -72,8 +72,8 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ProcessorModules = make(map[component.Type]string, len(factories.Processors))
-	factories.ProcessorModules[batchprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/batchprocessor v0.126.1"
-	factories.ProcessorModules[memorylimiterprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.1"
+	factories.ProcessorModules[batchprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/batchprocessor v0.126.2"
+	factories.ProcessorModules[memorylimiterprocessor.NewFactory().Type()] = "go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.2"
 
 	factories.Connectors, err = otelcol.MakeFactoryMap[connector.Factory](
 		forwardconnector.NewFactory(),
@@ -82,7 +82,7 @@ func components() (otelcol.Factories, error) {
 		return otelcol.Factories{}, err
 	}
 	factories.ConnectorModules = make(map[component.Type]string, len(factories.Connectors))
-	factories.ConnectorModules[forwardconnector.NewFactory().Type()] = "go.opentelemetry.io/collector/connector/forwardconnector v0.126.1"
+	factories.ConnectorModules[forwardconnector.NewFactory().Type()] = "go.opentelemetry.io/collector/connector/forwardconnector v0.126.2"
 
 	return factories, nil
 }

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -14,23 +14,23 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/forwardconnector v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/debugexporter v0.126.1
-	go.opentelemetry.io/collector/exporter/nopexporter v0.126.1
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/forwardconnector v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/debugexporter v0.126.2
+	go.opentelemetry.io/collector/exporter/nopexporter v0.126.2
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.126.2
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.1
-	go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
-	go.opentelemetry.io/collector/otelcol v0.126.1
+	go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.2
+	go.opentelemetry.io/collector/extension/zpagesextension v0.126.2
+	go.opentelemetry.io/collector/otelcol v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/batchprocessor v0.126.1
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.126.2
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/nopreceiver v0.126.1
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
+	go.opentelemetry.io/collector/receiver/nopreceiver v0.126.2
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.2
 	golang.org/x/sys v0.33.0
 )
 
@@ -84,55 +84,55 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector v0.126.1 // indirect
+	go.opentelemetry.io/collector v0.126.2 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.126.2 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.126.2 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.126.2 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/memorylimiter v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/memorylimiter v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/processorhelper v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
-	go.opentelemetry.io/collector/service v0.126.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/processorhelper v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/processortest v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
+	go.opentelemetry.io/collector/service v0.126.2 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -7,13 +7,13 @@ go 1.23.0
 toolchain go1.23.9
 
 require (
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/forwardconnector v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
@@ -21,14 +21,14 @@ require (
 	go.opentelemetry.io/collector/exporter/nopexporter v0.126.1
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/memorylimiterextension v0.126.1
 	go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
 	go.opentelemetry.io/collector/otelcol v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/batchprocessor v0.126.1
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/nopreceiver v0.126.1
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
 	golang.org/x/sys v0.33.0
@@ -85,23 +85,23 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.126.1 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.126.1 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.126.1 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.126.1 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/confignet v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/confignet v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configretry v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1 // indirect
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
@@ -109,17 +109,17 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/memorylimiter v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelcorecol",
 		Description: "Local OpenTelemetry Collector binary, testing only.",
-		Version:     "0.126.1-dev",
+		Version:     "0.126.2-dev",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -38,11 +38,11 @@ func main() {
 			},
 		},
 		ProviderModules: map[string]string{
-			envprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():   "go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.1",
-			fileprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1",
-			httpprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.1",
-			httpsprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme(): "go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.1",
-			yamlprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.1",
+			envprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():   "go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2",
+			fileprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2",
+			httpprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2",
+			httpsprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme(): "go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.32.2",
+			yamlprovider.NewFactory().Create(confmap.ProviderSettings{}).Scheme():  "go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2",
 		},
 		ConverterModules: []string{},
 	}

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
 )
 
@@ -17,9 +17,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/component/componentstatus/go.mod
+++ b/component/componentstatus/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/component/componenttest/go.mod
+++ b/component/componenttest/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/component/go.mod
+++ b/component/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 

--- a/component/go.mod
+++ b/component/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
-	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.1
+	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/config/configauth/go.mod
+++ b/config/configauth/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.1
 	go.uber.org/goleak v1.3.0
 )
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -5,21 +5,21 @@ go 1.23.0
 require (
 	github.com/mostynb/go-grpc-compression v1.2.3
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.32.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/client v1.32.2
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configauth v0.126.1
-	go.opentelemetry.io/collector/config/configcompression v1.32.1
+	go.opentelemetry.io/collector/config/configcompression v1.32.2
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1
-	go.opentelemetry.io/collector/config/confignet v1.32.1
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/config/configtls v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1
+	go.opentelemetry.io/collector/config/confignet v1.32.2
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/config/configtls v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
 	go.opentelemetry.io/otel v1.35.0
@@ -44,7 +44,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/config/configgrpc/go.mod
+++ b/config/configgrpc/go.mod
@@ -7,20 +7,20 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.32.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configauth v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configauth v0.126.2
 	go.opentelemetry.io/collector/config/configcompression v1.32.2
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2
 	go.opentelemetry.io/collector/config/confignet v1.32.2
 	go.opentelemetry.io/collector/config/configopaque v1.32.2
 	go.opentelemetry.io/collector/config/configtls v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
-	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.1
+	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.2
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2
+	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
 	go.opentelemetry.io/otel v1.35.0
 	go.uber.org/goleak v1.3.0
@@ -45,8 +45,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -10,17 +10,17 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.32.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configauth v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configauth v0.126.2
 	go.opentelemetry.io/collector/config/configcompression v1.32.2
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2
 	go.opentelemetry.io/collector/config/configopaque v1.32.2
 	go.opentelemetry.io/collector/config/configtls v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
-	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.1
+	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.2
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2
+	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.2
 	go.opentelemetry.io/collector/featuregate v1.32.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
 	go.opentelemetry.io/otel v1.35.0
@@ -42,7 +42,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/config/confighttp/go.mod
+++ b/config/confighttp/go.mod
@@ -8,20 +8,20 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.32.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/client v1.32.2
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configauth v0.126.1
-	go.opentelemetry.io/collector/config/configcompression v1.32.1
+	go.opentelemetry.io/collector/config/configcompression v1.32.2
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/config/configtls v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/config/configtls v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
 	go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.126.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.1
-	go.opentelemetry.io/collector/featuregate v1.32.1
+	go.opentelemetry.io/collector/featuregate v1.32.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
 	go.opentelemetry.io/otel v1.35.0
 	go.uber.org/goleak v1.3.0
@@ -43,7 +43,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/confighttp v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/confighttp v0.126.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
@@ -30,15 +30,15 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/component v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/config/confighttp/xconfighttp/go.mod
+++ b/config/confighttp/xconfighttp/go.mod
@@ -28,18 +28,18 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
-	go.opentelemetry.io/collector/component v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
+	go.opentelemetry.io/collector/component v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.32.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
 	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.1
 	google.golang.org/grpc v1.72.0
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/config/configmiddleware/go.mod
+++ b/config/configmiddleware/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
-	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.1
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2
+	go.opentelemetry.io/collector/extension/extensionmiddleware/extensionmiddlewaretest v0.126.2
 	google.golang.org/grpc v1.72.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/config/configtls/go.mod
+++ b/config/configtls/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-tpm v0.9.5
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
 )
 
 require (

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/knadh/koanf/providers/confmap v1.0.0
 	github.com/knadh/koanf/v2 v2.2.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/featuregate v1.32.1
+	go.opentelemetry.io/collector/featuregate v1.32.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0

--- a/confmap/internal/e2e/go.mod
+++ b/confmap/internal/e2e/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
 )
 
 require (
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/envprovider/go.mod
+++ b/confmap/provider/envprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/confmap/provider/fileprovider/go.mod
+++ b/confmap/provider/fileprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/httpprovider/go.mod
+++ b/confmap/provider/httpprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/httpsprovider/go.mod
+++ b/confmap/provider/httpsprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/provider/yamlprovider/go.mod
+++ b/confmap/provider/yamlprovider/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/xconfmap/go.mod
+++ b/confmap/xconfmap/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -5,14 +5,14 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.uber.org/goleak v1.3.0
 )
@@ -28,7 +28,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect

--- a/connector/connectortest/go.mod
+++ b/connector/connectortest/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -29,10 +29,10 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -5,14 +5,14 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -35,13 +35,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -4,14 +4,14 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.uber.org/goleak v1.3.0
 )
@@ -37,7 +37,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.uber.org/goleak v1.3.0
@@ -28,7 +28,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )
@@ -27,10 +27,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/connector v0.126.1
+	go.opentelemetry.io/collector/connector v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2
 )
 
 require (
@@ -29,7 +29,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/connector/xconnector/go.mod
+++ b/connector/xconnector/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1
@@ -28,9 +28,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 

--- a/consumer/consumererror/go.mod
+++ b/consumer/consumererror/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.uber.org/goleak v1.3.0

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 )
 
 require (

--- a/consumer/consumererror/xconsumererror/go.mod
+++ b/consumer/consumererror/xconsumererror/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -7,10 +7,10 @@ replace go.opentelemetry.io/collector/consumer => ../
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 

--- a/consumer/consumertest/go.mod
+++ b/consumer/consumertest/go.mod
@@ -6,9 +6,9 @@ replace go.opentelemetry.io/collector/consumer => ../
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.uber.org/goleak v1.3.0

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
 )
 
 require (

--- a/consumer/xconsumer/go.mod
+++ b/consumer/xconsumer/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 )
 
@@ -15,7 +15,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -5,17 +5,17 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configtelemetry v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.33.0
@@ -42,19 +42,19 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/exporter/debugexporter/go.mod
+++ b/exporter/debugexporter/go.mod
@@ -4,16 +4,16 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.uber.org/goleak v1.3.0
@@ -41,18 +41,18 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configretry v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -5,19 +5,19 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/config/configretry v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
@@ -46,14 +46,14 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect

--- a/exporter/exporterhelper/xexporterhelper/go.mod
+++ b/exporter/exporterhelper/xexporterhelper/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configretry v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/config/configretry v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
@@ -44,14 +44,14 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/confmap v1.32.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
+	go.opentelemetry.io/collector/confmap v1.32.2 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -6,18 +6,18 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/config/configretry v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
 	google.golang.org/grpc v1.72.0
 )
 
@@ -41,12 +41,12 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/exporter/exportertest/go.mod
+++ b/exporter/exportertest/go.mod
@@ -5,18 +5,18 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configretry v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/config/configretry v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	google.golang.org/grpc v1.72.0
 )
@@ -40,11 +40,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/confmap v1.32.1 // indirect
+	go.opentelemetry.io/collector/confmap v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -5,18 +5,18 @@ go 1.23.0
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.32.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/client v1.32.2
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configretry v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/config/configretry v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
 	go.opentelemetry.io/collector/extension/xextension v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
@@ -51,10 +51,10 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -7,19 +7,19 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.32.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/config/configretry v1.32.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
-	go.opentelemetry.io/collector/extension/xextension v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2
+	go.opentelemetry.io/collector/extension/xextension v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
@@ -49,14 +49,14 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
 	go.uber.org/goleak v1.3.0
 )
@@ -34,16 +34,16 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/exporter/nopexporter/go.mod
+++ b/exporter/nopexporter/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -33,15 +33,15 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -5,23 +5,23 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.126.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configauth v0.126.1
-	go.opentelemetry.io/collector/config/configcompression v1.32.1
+	go.opentelemetry.io/collector/config/configcompression v1.32.2
 	go.opentelemetry.io/collector/config/configgrpc v0.126.1
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/config/configretry v1.32.1
-	go.opentelemetry.io/collector/config/configtls v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/config/configretry v1.32.2
+	go.opentelemetry.io/collector/config/configtls v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.uber.org/goleak v1.3.0
@@ -57,21 +57,21 @@ require (
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/confignet v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/confignet v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -4,26 +4,26 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.126.1
+	go.opentelemetry.io/collector v0.126.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configauth v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configauth v0.126.2
 	go.opentelemetry.io/collector/config/configcompression v1.32.2
-	go.opentelemetry.io/collector/config/configgrpc v0.126.1
+	go.opentelemetry.io/collector/config/configgrpc v0.126.2
 	go.opentelemetry.io/collector/config/configopaque v1.32.2
 	go.opentelemetry.io/collector/config/configretry v1.32.2
 	go.opentelemetry.io/collector/config/configtls v1.32.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a
@@ -58,22 +58,22 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -5,22 +5,22 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.126.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configcompression v1.32.1
+	go.opentelemetry.io/collector/config/configcompression v1.32.2
 	go.opentelemetry.io/collector/config/confighttp v0.126.1
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/config/configretry v1.32.1
-	go.opentelemetry.io/collector/config/configtls v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/config/configretry v1.32.2
+	go.opentelemetry.io/collector/config/configtls v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -57,21 +57,21 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -4,24 +4,24 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.126.1
+	go.opentelemetry.io/collector v0.126.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/config/configcompression v1.32.2
-	go.opentelemetry.io/collector/config/confighttp v0.126.1
+	go.opentelemetry.io/collector/config/confighttp v0.126.2
 	go.opentelemetry.io/collector/config/configopaque v1.32.2
 	go.opentelemetry.io/collector/config/configretry v1.32.2
 	go.opentelemetry.io/collector/config/configtls v1.32.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a
@@ -58,22 +58,22 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.126.2 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
@@ -23,10 +23,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/exporter/xexporter/go.mod
+++ b/exporter/xexporter/go.mod
@@ -5,10 +5,10 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 )
 
 require (
@@ -25,9 +25,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/extensionauth/extensionauthtest/go.mod
+++ b/extension/extensionauth/extensionauthtest/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.72.0
 )
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -3,9 +3,9 @@ module go.opentelemetry.io/collector/extension/extensioncapabilities
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
 )
 
 require (
@@ -22,9 +22,9 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/extensioncapabilities/go.mod
+++ b/extension/extensioncapabilities/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2
 	google.golang.org/grpc v1.72.0
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
+++ b/extension/extensionmiddleware/extensionmiddlewaretest/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1
 	google.golang.org/grpc v1.72.0
 )
@@ -19,9 +19,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -7,9 +7,9 @@ replace go.opentelemetry.io/collector/extension => ..
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/extension v1.32.2
 )
 
 require (
@@ -20,9 +20,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/extensiontest/go.mod
+++ b/extension/extensiontest/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/extension v1.32.2
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -17,9 +17,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/go.mod
+++ b/extension/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
-	go.opentelemetry.io/collector/internal/memorylimiter v0.126.1
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2
+	go.opentelemetry.io/collector/internal/memorylimiter v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -39,7 +39,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/memorylimiterextension/go.mod
+++ b/extension/memorylimiterextension/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
 	go.opentelemetry.io/collector/internal/memorylimiter v0.126.1
 	go.uber.org/goleak v1.3.0
@@ -38,9 +38,9 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/xextension/go.mod
+++ b/extension/xextension/go.mod
@@ -3,8 +3,8 @@ module go.opentelemetry.io/collector/extension/xextension
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
 )
 
 require (
@@ -14,9 +14,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -4,15 +4,15 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.126.1
+	go.opentelemetry.io/collector v0.126.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configauth v0.126.1
-	go.opentelemetry.io/collector/config/confighttp v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configauth v0.126.2
+	go.opentelemetry.io/collector/config/confighttp v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2
 	go.opentelemetry.io/contrib/zpages v0.60.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
@@ -46,15 +46,15 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -5,13 +5,13 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.126.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configauth v0.126.1
 	go.opentelemetry.io/collector/config/confighttp v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
 	go.opentelemetry.io/contrib/zpages v0.60.0
 	go.opentelemetry.io/otel/sdk v1.35.0
@@ -44,16 +44,16 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.32.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect

--- a/filter/go.mod
+++ b/filter/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,36 +4,36 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.126.1
+	go.opentelemetry.io/collector v0.126.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configauth v0.126.1
-	go.opentelemetry.io/collector/config/configgrpc v0.126.1
-	go.opentelemetry.io/collector/config/confighttp v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configauth v0.126.2
+	go.opentelemetry.io/collector/config/configgrpc v0.126.2
+	go.opentelemetry.io/collector/config/confighttp v0.126.2
 	go.opentelemetry.io/collector/config/confignet v1.32.2
 	go.opentelemetry.io/collector/config/configopaque v1.32.2
 	go.opentelemetry.io/collector/config/configretry v1.32.2
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
+	go.opentelemetry.io/collector/config/configtelemetry v0.126.2
 	go.opentelemetry.io/collector/config/configtls v1.32.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.126.2
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.1
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/service v0.126.1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.2
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/service v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -86,29 +86,29 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/processor v1.32.2 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1 // indirect
+	go.opentelemetry.io/collector/processor/processortest v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,32 +5,32 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.126.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configauth v0.126.1
 	go.opentelemetry.io/collector/config/configgrpc v0.126.1
 	go.opentelemetry.io/collector/config/confighttp v0.126.1
-	go.opentelemetry.io/collector/config/confignet v1.32.1
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/config/configretry v1.32.1
+	go.opentelemetry.io/collector/config/confignet v1.32.2
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/config/configretry v1.32.2
 	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
-	go.opentelemetry.io/collector/config/configtls v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/config/configtls v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.126.1
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.126.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.126.1
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.opentelemetry.io/collector/service v0.126.1
@@ -84,8 +84,8 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
@@ -93,17 +93,17 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor v1.32.1 // indirect
+	go.opentelemetry.io/collector/processor v1.32.2 // indirect
 	go.opentelemetry.io/collector/processor/processortest v0.126.1 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1 // indirect

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/internal/fanoutconsumer/go.mod
+++ b/internal/fanoutconsumer/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.uber.org/goleak v1.3.0

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/shirou/gopsutil/v4 v4.25.4
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -34,9 +34,9 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/internal/memorylimiter/go.mod
+++ b/internal/memorylimiter/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -20,9 +20,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.uber.org/goleak v1.3.0
@@ -19,9 +19,9 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/featuregate v1.32.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/log v0.11.0

--- a/internal/telemetry/go.mod
+++ b/internal/telemetry/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/featuregate v1.32.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/featuregate v1.32.2
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0
 	go.opentelemetry.io/otel v1.35.0

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -6,25 +6,25 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/config/configtelemetry v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2
 	go.opentelemetry.io/collector/featuregate v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/service v0.126.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/service v0.126.2
 	go.opentelemetry.io/contrib/otelconf v0.15.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -74,23 +74,23 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -5,24 +5,24 @@ go 1.23.0
 require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
-	go.opentelemetry.io/collector/featuregate v1.32.1
+	go.opentelemetry.io/collector/featuregate v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.opentelemetry.io/collector/service v0.126.1
 	go.opentelemetry.io/contrib/otelconf v0.15.0
@@ -76,7 +76,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componenttest v0.126.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
@@ -84,7 +84,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -4,12 +4,12 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.1
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/envprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
@@ -67,24 +67,24 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/connector v0.126.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter v0.126.1 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor v1.32.1 // indirect
+	go.opentelemetry.io/collector/processor v1.32.2 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver v1.32.1 // indirect
+	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/otelcol/otelcoltest/go.mod
+++ b/otelcol/otelcoltest/go.mod
@@ -10,15 +10,15 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.32.2
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.32.2
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
-	go.opentelemetry.io/collector/otelcol v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/service v0.126.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2
+	go.opentelemetry.io/collector/otelcol v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/service v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -62,31 +62,31 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector v0.126.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
+	go.opentelemetry.io/collector/component/componenttest v0.126.2 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector v0.126.2 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter v0.126.1 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter v0.126.2 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2 // indirect
 	go.opentelemetry.io/collector/processor v1.32.2 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
 	go.opentelemetry.io/collector/receiver v1.32.2 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/otelconf v0.15.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0 // indirect

--- a/pdata/pprofile/go.mod
+++ b/pdata/pprofile/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/json-iterator/go v1.1.12
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.72.0
 )

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/collector/pdata/testdata
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 )
 

--- a/pdata/testdata/go.mod
+++ b/pdata/testdata/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
 )
 
 require (

--- a/pipeline/xpipeline/go.mod
+++ b/pipeline/xpipeline/go.mod
@@ -2,6 +2,6 @@ module go.opentelemetry.io/collector/pipeline/xpipeline
 
 go 1.23.0
 
-require go.opentelemetry.io/collector/pipeline v0.126.1
+require go.opentelemetry.io/collector/pipeline v0.126.2
 
 replace go.opentelemetry.io/collector/pipeline => ../

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -4,16 +4,16 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/client v1.32.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/client v1.32.2
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
@@ -44,7 +44,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.32.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
@@ -42,13 +42,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -23,11 +23,11 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.uber.org/goleak v1.3.0
@@ -24,9 +24,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -5,23 +5,23 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/internal/memorylimiter v0.126.1
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/internal/memorylimiter v0.126.2
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processorhelper v0.126.1
-	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.1
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
+	go.opentelemetry.io/collector/processor/processorhelper v0.126.2
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.2
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
@@ -57,9 +57,9 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -4,20 +4,20 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/internal/memorylimiter v0.126.1
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processorhelper v0.126.1
 	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.1
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
@@ -58,7 +58,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -6,13 +6,13 @@ replace go.opentelemetry.io/collector/processor => ../
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
@@ -35,7 +35,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect

--- a/processor/processorhelper/go.mod
+++ b/processor/processorhelper/go.mod
@@ -7,13 +7,13 @@ replace go.opentelemetry.io/collector/processor => ../
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
@@ -33,13 +33,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processorhelper v0.126.1
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
+	go.opentelemetry.io/collector/processor/processorhelper v0.126.2
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2
 )
 
 require (
@@ -28,12 +28,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/processor/processorhelper/xprocessorhelper/go.mod
+++ b/processor/processorhelper/xprocessorhelper/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processorhelper v0.126.1
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
 	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
@@ -29,9 +29,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -4,17 +4,17 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
 	go.uber.org/goleak v1.3.0
 )
@@ -31,7 +31,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/processor/processortest/go.mod
+++ b/processor/processortest/go.mod
@@ -5,17 +5,17 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -32,7 +32,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 )
 
 require (
@@ -23,10 +23,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/processor/xprocessor/go.mod
+++ b/processor/xprocessor/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
 )
 
@@ -25,9 +25,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.uber.org/goleak v1.3.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -24,10 +24,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -5,13 +5,13 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -35,13 +35,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/receiver/nopreceiver/go.mod
+++ b/receiver/nopreceiver/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -37,7 +37,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -6,31 +6,31 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/klauspost/compress v1.18.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.126.1
+	go.opentelemetry.io/collector v0.126.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/configauth v0.126.1
-	go.opentelemetry.io/collector/config/configgrpc v0.126.1
-	go.opentelemetry.io/collector/config/confighttp v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/configauth v0.126.2
+	go.opentelemetry.io/collector/config/configgrpc v0.126.2
+	go.opentelemetry.io/collector/config/confighttp v0.126.2
 	go.opentelemetry.io/collector/config/confignet v1.32.2
 	go.opentelemetry.io/collector/config/configopaque v1.32.2
 	go.opentelemetry.io/collector/config/configtls v1.32.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.1
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.2
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.2
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
 	go.uber.org/goleak v1.3.0
@@ -68,11 +68,11 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -7,27 +7,27 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.126.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/configauth v0.126.1
 	go.opentelemetry.io/collector/config/configgrpc v0.126.1
 	go.opentelemetry.io/collector/config/confighttp v0.126.1
-	go.opentelemetry.io/collector/config/confignet v1.32.1
-	go.opentelemetry.io/collector/config/configopaque v1.32.1
-	go.opentelemetry.io/collector/config/configtls v1.32.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/config/confignet v1.32.2
+	go.opentelemetry.io/collector/config/configopaque v1.32.2
+	go.opentelemetry.io/collector/config/configtls v1.32.2
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.126.1
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1
@@ -66,12 +66,12 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -4,10 +4,10 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk/metric v1.35.0
@@ -27,10 +27,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect

--- a/receiver/receiverhelper/go.mod
+++ b/receiver/receiverhelper/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
@@ -29,7 +29,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2
 	go.uber.org/goleak v1.3.0
 )
 
@@ -30,8 +30,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/receiver/receivertest/go.mod
+++ b/receiver/receivertest/go.mod
@@ -5,15 +5,15 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1
 	go.uber.org/goleak v1.3.0
 )
@@ -29,7 +29,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
 )
 
@@ -25,9 +25,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/receiver/xreceiver/go.mod
+++ b/receiver/xreceiver/go.mod
@@ -4,11 +4,11 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 )
 
 require (
@@ -23,10 +23,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer v1.32.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/consumer v1.32.2 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -4,9 +4,9 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -24,7 +24,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -4,14 +4,14 @@ go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.opentelemetry.io/collector/scraper v0.126.1
@@ -39,7 +39,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect

--- a/scraper/scraperhelper/go.mod
+++ b/scraper/scraperhelper/go.mod
@@ -5,16 +5,16 @@ go 1.23.0
 require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.1
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/scraper v0.126.1
+	go.opentelemetry.io/collector/receiver/receiverhelper v0.126.2
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/scraper v0.126.2
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
@@ -37,12 +37,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/scraper v0.126.1
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/scraper v0.126.2
 )
 
 require (
@@ -19,9 +19,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
+	go.opentelemetry.io/collector/pipeline v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/scraper/scrapertest/go.mod
+++ b/scraper/scrapertest/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/scraper v0.126.1
 )
@@ -18,9 +18,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/service/go.mod
+++ b/service/go.mod
@@ -8,43 +8,43 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/shirou/gopsutil/v4 v4.25.4
 	github.com/stretchr/testify v1.10.0
-	go.opentelemetry.io/collector v0.126.1
+	go.opentelemetry.io/collector v0.126.2
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/component/componentstatus v0.126.1
-	go.opentelemetry.io/collector/component/componenttest v0.126.1
-	go.opentelemetry.io/collector/config/confighttp v0.126.1
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
+	go.opentelemetry.io/collector/component/componentstatus v0.126.2
+	go.opentelemetry.io/collector/component/componenttest v0.126.2
+	go.opentelemetry.io/collector/config/confighttp v0.126.2
+	go.opentelemetry.io/collector/config/configtelemetry v0.126.2
 	go.opentelemetry.io/collector/confmap v1.32.2
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
-	go.opentelemetry.io/collector/connector v0.126.1
-	go.opentelemetry.io/collector/connector/connectortest v0.126.1
-	go.opentelemetry.io/collector/connector/xconnector v0.126.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.126.2
+	go.opentelemetry.io/collector/connector v0.126.2
+	go.opentelemetry.io/collector/connector/connectortest v0.126.2
+	go.opentelemetry.io/collector/connector/xconnector v0.126.2
 	go.opentelemetry.io/collector/consumer v1.32.2
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
-	go.opentelemetry.io/collector/exporter v0.126.1
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
+	go.opentelemetry.io/collector/consumer/consumertest v0.126.2
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.2
+	go.opentelemetry.io/collector/exporter v0.126.2
+	go.opentelemetry.io/collector/exporter/exportertest v0.126.2
+	go.opentelemetry.io/collector/exporter/xexporter v0.126.2
 	go.opentelemetry.io/collector/extension v1.32.2
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
-	go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.2
+	go.opentelemetry.io/collector/extension/extensiontest v0.126.2
+	go.opentelemetry.io/collector/extension/zpagesextension v0.126.2
 	go.opentelemetry.io/collector/featuregate v1.32.2
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1
-	go.opentelemetry.io/collector/otelcol v0.126.1
+	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.2
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2
+	go.opentelemetry.io/collector/otelcol v0.126.2
 	go.opentelemetry.io/collector/pdata v1.32.2
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
-	go.opentelemetry.io/collector/pdata/testdata v0.126.1
-	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.2
+	go.opentelemetry.io/collector/pdata/testdata v0.126.2
+	go.opentelemetry.io/collector/pipeline v0.126.2
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.2
 	go.opentelemetry.io/collector/processor v1.32.2
-	go.opentelemetry.io/collector/processor/processortest v0.126.1
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
+	go.opentelemetry.io/collector/processor/processortest v0.126.2
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.2
 	go.opentelemetry.io/collector/receiver v1.32.2
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1
-	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1
+	go.opentelemetry.io/collector/receiver/receivertest v0.126.2
+	go.opentelemetry.io/collector/receiver/xreceiver v0.126.2
+	go.opentelemetry.io/collector/service/hostcapabilities v0.126.2
 	go.opentelemetry.io/contrib/otelconf v0.15.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0
 	go.opentelemetry.io/otel v1.35.0
@@ -103,14 +103,14 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/config/configmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v0.126.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/contrib/zpages v0.60.0 // indirect

--- a/service/go.mod
+++ b/service/go.mod
@@ -9,39 +9,39 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.4
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector v0.126.1
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1
 	go.opentelemetry.io/collector/component/componenttest v0.126.1
 	go.opentelemetry.io/collector/config/confighttp v0.126.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.126.1
-	go.opentelemetry.io/collector/confmap v1.32.1
+	go.opentelemetry.io/collector/confmap v1.32.2
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1
 	go.opentelemetry.io/collector/connector v0.126.1
 	go.opentelemetry.io/collector/connector/connectortest v0.126.1
 	go.opentelemetry.io/collector/connector/xconnector v0.126.1
-	go.opentelemetry.io/collector/consumer v1.32.1
+	go.opentelemetry.io/collector/consumer v1.32.2
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1
 	go.opentelemetry.io/collector/exporter v0.126.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.126.1
 	go.opentelemetry.io/collector/exporter/xexporter v0.126.1
-	go.opentelemetry.io/collector/extension v1.32.1
+	go.opentelemetry.io/collector/extension v1.32.2
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.1
 	go.opentelemetry.io/collector/extension/extensiontest v0.126.1
 	go.opentelemetry.io/collector/extension/zpagesextension v0.126.1
-	go.opentelemetry.io/collector/featuregate v1.32.1
+	go.opentelemetry.io/collector/featuregate v1.32.2
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.1
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1
 	go.opentelemetry.io/collector/otelcol v0.126.1
-	go.opentelemetry.io/collector/pdata v1.32.1
+	go.opentelemetry.io/collector/pdata v1.32.2
 	go.opentelemetry.io/collector/pdata/pprofile v0.126.1
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.1
-	go.opentelemetry.io/collector/processor v1.32.1
+	go.opentelemetry.io/collector/processor v1.32.2
 	go.opentelemetry.io/collector/processor/processortest v0.126.1
 	go.opentelemetry.io/collector/processor/xprocessor v0.126.1
-	go.opentelemetry.io/collector/receiver v1.32.1
+	go.opentelemetry.io/collector/receiver v1.32.2
 	go.opentelemetry.io/collector/receiver/receivertest v0.126.1
 	go.opentelemetry.io/collector/receiver/xreceiver v0.126.1
 	go.opentelemetry.io/collector/service/hostcapabilities v0.126.1
@@ -102,14 +102,14 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/client v1.32.1 // indirect
+	go.opentelemetry.io/collector/client v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.32.2 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.126.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.32.1 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.32.1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.32.2 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.32.2 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.126.1 // indirect
-	go.opentelemetry.io/collector/extension/extensionauth v1.32.1 // indirect
+	go.opentelemetry.io/collector/extension/extensionauth v1.32.2 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.126.1 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -3,7 +3,7 @@ module go.opentelemetry.io/collector/service/hostcapabilities
 go 1.23.0
 
 require (
-	go.opentelemetry.io/collector/component v1.32.1
+	go.opentelemetry.io/collector/component v1.32.2
 	go.opentelemetry.io/collector/pipeline v0.126.1
 	go.opentelemetry.io/collector/service v0.126.1
 )
@@ -15,9 +15,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.32.1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
-	go.opentelemetry.io/collector/pdata v1.32.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect

--- a/service/hostcapabilities/go.mod
+++ b/service/hostcapabilities/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	go.opentelemetry.io/collector/component v1.32.2
-	go.opentelemetry.io/collector/pipeline v0.126.1
-	go.opentelemetry.io/collector/service v0.126.1
+	go.opentelemetry.io/collector/pipeline v0.126.2
+	go.opentelemetry.io/collector/service v0.126.2
 )
 
 require (
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.2 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.1 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.126.2 // indirect
 	go.opentelemetry.io/collector/pdata v1.32.2 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/versions.yaml
+++ b/versions.yaml
@@ -26,7 +26,7 @@ module-sets:
       - go.opentelemetry.io/collector/processor
       - go.opentelemetry.io/collector/receiver
   beta:
-    version: v0.126.1
+    version: v0.126.2
     modules:
       - go.opentelemetry.io/collector
       - go.opentelemetry.io/collector/internal/memorylimiter

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   stable:
-    version: v1.32.1
+    version: v1.32.2
     modules:
       - go.opentelemetry.io/collector/client
       - go.opentelemetry.io/collector/featuregate


### PR DESCRIPTION

The following commands were run to prepare this release:
- make chlog-update VERSION=v1.32.2/v0.126.2
- make prepare-release PREVIOUS_VERSION=1[.]32[.]1 RELEASE_CANDIDATE=1.32.2 MODSET=stable
- make prepare-release PREVIOUS_VERSION=0[.]126[.]1 RELEASE_CANDIDATE=0.126.2 MODSET=beta
